### PR TITLE
Fix setup script

### DIFF
--- a/script/setup.sh
+++ b/script/setup.sh
@@ -13,7 +13,6 @@ pushd cache
 
 NODEJS_VERSION=0.10.33
 ATOM_SHELL_VERSION=0.19.4
-ATOM_SHELL_FILE=atom-shell-v$ATOM_SHELL_VERSION-$OS_ARCH.zip
 
 OS_PLATFORM=`uname -s`
 OS_PLATFORM=`echo $OS_PLATFORM | tr '[:upper:]' '[:lower:]'`
@@ -28,6 +27,7 @@ fi
 
 echo "OS Architecture: $OS_ARCH"
 
+ATOM_SHELL_FILE=atom-shell-v$ATOM_SHELL_VERSION-$OS_ARCH.zip
 
 if [ ! -f $ATOM_SHELL_FILE ]; then
   cecho "-----> Downloading Atom Shell..." $purple


### PR DESCRIPTION
After a fresh install I found that the `ATOM_SHELL_FILE` was incorrect because `OS_ARCH` was not defined. 

```
Archive:  atom-shell-v0.19.4-.zip
  End-of-central-directory signature not found.  
...
```

I moved the `ATOM_SHELL_FILE` definition below the `OS_ARCH` definition to fix this.
